### PR TITLE
Update Docker configuration

### DIFF
--- a/iteration-five/docker/web/Dockerfile
+++ b/iteration-five/docker/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0-apache
+FROM php:7.3-apache
 
 WORKDIR /var/www/html
 

--- a/iteration-four/docker-compose.yml
+++ b/iteration-four/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
     nginx:
-        image: nginx
+        image: nginx:stable
         ports:
             - 8080:80
         volumes:

--- a/iteration-four/docker/php/Dockerfile
+++ b/iteration-four/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm
+FROM php:7.3-fpm
 
 RUN docker-php-ext-install pdo_mysql \
     && docker-php-ext-install json

--- a/iteration-one/docker-compose.yml
+++ b/iteration-one/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
     nginx:
-        image: nginx
+        image: nginx:stable
         ports:
             - 8080:80
         volumes:

--- a/iteration-one/docker.build
+++ b/iteration-one/docker.build
@@ -1,5 +1,5 @@
 # Use PHP version 7.0 with FPM
-FROM php:7.0-fpm
+FROM php:7.3-fpm
 
 # Maintainer and license information
 MAINTAINER Matthew Setter <matthew@matthewsetter.com>

--- a/iteration-one/docker/php/Dockerfile
+++ b/iteration-one/docker/php/Dockerfile
@@ -1,4 +1,23 @@
-FROM php:7.1-fpm
+FROM php:7.3-fpm
 
+# Maintainer and license information
+MAINTAINER Matthew Setter <matthew@matthewsetter.com>
+
+# Expose the required ports for the application
+EXPOSE 9000
+
+# Create the required directory structure for the application
+# and copy the code to it from the local working copy
+RUN mkdir -p /var/www/html
+COPY . /var/www/html
+WORKDIR /var/www/html
+
+# Install PHP's required dependencies
 RUN docker-php-ext-install pdo_mysql \
     && docker-php-ext-install json
+
+# Add binaries required for using Composer
+RUN apt-get update \
+    && apt-get --yes --force-yes install git \
+    && apt-get --yes --force-yes install zip \
+    && apt-get --yes --force-yes install unzip

--- a/iteration-three/docker-compose.yml
+++ b/iteration-three/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
     nginx:
-        image: nginx
+        image: nginx:stable
         ports:
             - 8080:80
         volumes:

--- a/iteration-three/docker/php/Dockerfile
+++ b/iteration-three/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm
+FROM php:7.3-fpm
 
 RUN docker-php-ext-install pdo_mysql \
     && docker-php-ext-install json

--- a/iteration-two/docker-compose.yml
+++ b/iteration-two/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
     nginx:
-        image: nginx
+        image: nginx:stable
         ports:
             - 8080:80
         volumes:

--- a/iteration-two/docker/php/Dockerfile
+++ b/iteration-two/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm
+FROM php:7.3-fpm
 
 RUN docker-php-ext-install pdo_mysql \
     && docker-php-ext-install json


### PR DESCRIPTION
Updated the Docker configuration to use PHP 7.3 and NGINX to use the stable container. The change to PHP was mainly because 7.1’s outdated now. The change to the NGINX Docker container was much more important, as it’s know to be a problem if the stable container’s not used.

For more information, refer to https://github.com/nginxinc/docker-nginx/issues/262.